### PR TITLE
Bump package version to 1.6.16

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php5-mongo
 _pkgrealname=mongo
 _pkgsrcname=mongo-php-driver-legacy
-pkgver=1.6.15
+pkgver=1.6.16
 pkgrel=0
 pkgdesc="MongoDB driver for PHP 5"
 url="https://github.com/mongodb/$_pkgsrcname"
@@ -56,4 +56,4 @@ doc() {
 	done
 }
 
-sha512sums="afd92669c410d58c99e3e6d9ad776552b6161efbcfff69768029eab2bba158be9cd96d69acb7464d502051bbc28192dee20e4624f5d42ea7f6b2e613f1b46bf9  php5-mongo-1.6.15.tar.gz"
+sha512sums="f5713dd2494315e4f13d7138d18b8041fe273132f09cf87372d2bb8ebea2a72783dd1bab17d9ad48f2491d2868206062791a381a3e6425dfa9e7963fb755041f  php5-mongo-1.6.16.tar.gz"

--- a/circle.yml
+++ b/circle.yml
@@ -13,11 +13,11 @@ dependencies:
     - mkdir packages
     - echo -e "$RSA_PUBLIC_KEY" > packages/sgerrand.rsa.pub
   override:
-    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -e RSA_PRIVATE_KEY_NAME="sgerrand.rsa" -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages sgerrand/alpine-abuild:3.4
+    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -e RSA_PRIVATE_KEY_NAME="sgerrand.rsa" -v $PWD:/home/builder/package -v $PWD/packages:/packages sgerrand/alpine-abuild:v3
 
 test:
   override:
-    - docker run -it -v $(pwd)/packages:/packages alpine:3.4 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+    - docker run -it -v $(pwd)/packages:/packages alpine:3.5 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
 
 deployment:
   release:


### PR DESCRIPTION
💁 These changes bump the package version to [1.6.16](https://github.com/mongodb/mongo-php-driver-legacy/releases/tag/1.6.16).